### PR TITLE
Add three featured cards on the front page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -105,6 +105,35 @@
         those talks (or at least, all of the talks I can find) in one place.</p>
       <p>It'll take a while to get everything up here, but I'll be adding talks as I find them.</p>
       <p>Watch this space.</p>
+
+      <h2>Recent Talks</h2>
+      <div class="row mb-2">
+        <div class="col-md-4">
+          <div class="card mb-4 shadow-sm">
+            <div class="card-body">
+              <h5 class="card-title">Still Munging Data With Perl</h5>
+              <a href="/talk/still-munging-data-with-perl/" class="btn btn-primary">Read more</a>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card mb-4 shadow-sm">
+            <div class="card-body">
+              <h5 class="card-title">Perl School Update</h5>
+              <a href="/talk/perl-school-update/" class="btn btn-primary">Read more</a>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card mb-4 shadow-sm">
+            <div class="card-body">
+              <h5 class="card-title">Perl Diver</h5>
+              <a href="/talk/perl-diver/" class="btn btn-primary">Read more</a>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <h2>Finding talks</h2>
       <p>You can currently find talks by:</p>
       <ul>
@@ -113,6 +142,7 @@
         <li><a href="/type/">Talk type</a></li>
         <li><a href="/talk/">Talk title</a></li>
       </ul>
+
 
         </div>
       </div>

--- a/lib/Talks.pm
+++ b/lib/Talks.pm
@@ -69,7 +69,7 @@ class Talks {
     my $recent_presentations = $schema->resultset('Presentation')->search(
       {},
       {
-        order_by => { -desc => 'date' },
+        order_by => { -desc => 'datetime' },
         rows     => 3,
       }
     );

--- a/lib/Talks.pm
+++ b/lib/Talks.pm
@@ -66,8 +66,17 @@ class Talks {
       description => 'A collection of talks by Dave Cross',
     );
     push @urls, $index->url_path;
+    my $recent_presentations = $schema->resultset('Presentation')->search(
+      {},
+      {
+        order_by => { -desc => 'date' },
+        rows     => 3,
+      }
+    );
+    my @recent_talks = map { $_->talk } $recent_presentations->all;
     $tt->process('index.tt', {
       object => $index,
+      recent_talks => \@recent_talks,
     }, $index->outfile)
       or die $tt->error;
   }

--- a/ttlib/index.tt
+++ b/ttlib/index.tt
@@ -12,4 +12,17 @@
         <li><a href="/type/">Talk type</a></li>
         <li><a href="/talk/">Talk title</a></li>
       </ul>
+      <h2>Recent Talks</h2>
+      <div class="row mb-2">
+[% FOREACH talk IN recent_talks -%]
+        <div class="col-md-4">
+          <div class="card mb-4 shadow-sm">
+            <div class="card-body">
+              <h5 class="card-title">[% talk.title %]</h5>
+              <a href="[% talk.url_path %]" class="btn btn-primary">Read more</a>
+            </div>
+          </div>
+        </div>
+[% END -%]
+      </div>
 [% END -%]

--- a/ttlib/index.tt
+++ b/ttlib/index.tt
@@ -4,14 +4,7 @@
         those talks (or at least, all of the talks I can find) in one place.</p>
       <p>It'll take a while to get everything up here, but I'll be adding talks as I find them.</p>
       <p>Watch this space.</p>
-      <h2>Finding talks</h2>
-      <p>You can currently find talks by:</p>
-      <ul>
-        <li><a href="/year/">Year</a></li>
-        <li><a href="/event/">Event</a></li>
-        <li><a href="/type/">Talk type</a></li>
-        <li><a href="/talk/">Talk title</a></li>
-      </ul>
+
       <h2>Recent Talks</h2>
       <div class="row mb-2">
 [% FOREACH talk IN recent_talks -%]
@@ -25,4 +18,14 @@
         </div>
 [% END -%]
       </div>
+
+      <h2>Finding talks</h2>
+      <p>You can currently find talks by:</p>
+      <ul>
+        <li><a href="/year/">Year</a></li>
+        <li><a href="/event/">Event</a></li>
+        <li><a href="/type/">Talk type</a></li>
+        <li><a href="/talk/">Talk title</a></li>
+      </ul>
+
 [% END -%]


### PR DESCRIPTION
Fixes #12

Add three featured cards on the front page to display the titles of the three most recent talks.

* Update `lib/Talks.pm` to fetch the three most recent presentations and their associated talks in the `build_index` method.
* Pass the recent talks to the front page template in `lib/Talks.pm`.
* Modify `ttlib/index.tt` to include logic to display featured cards for the three most recent talks.
* Use a loop in `ttlib/index.tt` to iterate over the recent talks and display their titles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/talks/pull/13?shareId=e81cd50d-eee8-433a-b465-ac5a0e912cd1).